### PR TITLE
single Makefile.inc and build.sh for scotch and ptscotch

### DIFF
--- a/recipe/Makefile.inc
+++ b/recipe/Makefile.inc
@@ -1,23 +1,22 @@
-# -*- makefile -*-
+# -*- mode: makefile-gmake -*-
 
-EXE             =
-LIB             = .a
-OBJ             = .o
+EXE         =
+LIB         = .a
+OBJ         = .o
 
-MAKE            = make
-AR              = ar
-ARFLAGS         = -ruv
-CAT             = cat
-CCS            := ${CC}
-CCP             = mpicc
-CCD            := ${CC}
-CFLAGS         := ${CFLAGS}
-CLIBFLAGS      := ${CLIBFLAGS}
-LDFLAGS        := ${LDFLAGS}
-CP              = cp
-LEX             = flex -Pscotchyy --no-yywrap -olex.yy.c
-LN              = ln
-MKDIR           = mkdir
-MV              = mv
-RANLIB          = ranlib
-YACC            = bison -pscotchyy -y -b y
+AR          = ar
+ARFLAGS     = -ruv
+CAT         = cat
+CCS         = ${CC}
+CCP         = mpicc
+CCD         = ${CC}
+CFLAGS     := ${CFLAGS}
+CLIBFLAGS   = -fPIC
+LDFLAGS    := $(filter-out -lc++,${LDFLAGS})
+CP          = cp
+LEX         = flex -Pscotchyy -olex.yy.c
+LN          = ln
+MKDIR       = mkdir
+MV          = mv
+RANLIB      = ranlib
+YACC        = bison -pscotchyy -y -b y

--- a/recipe/Makefile.inc
+++ b/recipe/Makefile.inc
@@ -1,4 +1,5 @@
 # -*- makefile -*-
+
 EXE             =
 LIB             = .a
 OBJ             = .o
@@ -7,12 +8,12 @@ MAKE            = make
 AR              = ar
 ARFLAGS         = -ruv
 CAT             = cat
-CCS             = gcc
+CCS            := ${CC}
 CCP             = mpicc
-CCD             = gcc
-CFLAGS          = -I${PREFIX}/include -O3 -DIDXSIZE64 -Drestrict=__restrict -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_RANDOM_FIXED_SEED -DSCOTCH_RENAME -DCOMMON_PTHREAD -DCOMMON_PTHREAD_BARRIER -DSCOTCH_PTHREAD
-CLIBFLAGS       =
-LDFLAGS         = -L${PREFIX}/lib -lz -lm -pthread
+CCD            := ${CC}
+CFLAGS         := ${CFLAGS}
+CLIBFLAGS      := ${CLIBFLAGS}
+LDFLAGS        := ${LDFLAGS}
 CP              = cp
 LEX             = flex -Pscotchyy --no-yywrap -olex.yy.c
 LN              = ln

--- a/recipe/Makefile.inc.Darwin
+++ b/recipe/Makefile.inc.Darwin
@@ -1,8 +1,0 @@
-# -*- makefile -*-
-src_dir := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-include $(src_dir)/Makefile.inc.common
-
-CCS             = clang
-CCD             = clang
-CLIBFLAGS      := $(CLIBFLAGS) -fPIC
-LDFLAGS        := $(LDFLAGS) -Wl,-headerpad_max_install_names

--- a/recipe/Makefile.inc.Darwin
+++ b/recipe/Makefile.inc.Darwin
@@ -1,22 +1,8 @@
 # -*- makefile -*-
-EXE             =
-LIB             = .a
-OBJ             = .o
+src_dir := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+include $(src_dir)/Makefile.inc.common
 
-MAKE            = make
-AR              = ar
-ARFLAGS         = -ruv
-CAT             = cat
 CCS             = clang
-CCP             = clang
 CCD             = clang
-CFLAGS          = -I${PREFIX}/include -O3 -DIDXSIZE64 -Drestrict=__restrict -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_RANDOM_FIXED_SEED -DSCOTCH_RENAME -DCOMMON_PTHREAD -DSCOTCH_PTHREAD -DCOMMON_PTHREAD_BARRIER -DCOMMON_TIMING_OLD
-CLIBFLAGS       = -fPIC
-LDFLAGS         = -L${PREFIX}/lib -lz -lm -pthread -Wl,-headerpad_max_install_names
-CP              = cp
-LEX             = flex -Pscotchyy -olex.yy.c
-LN              = ln
-MKDIR           = mkdir
-MV              = mv
-RANLIB          = ranlib
-YACC            = bison -pscotchyy -y -b y
+CLIBFLAGS      := $(CLIBFLAGS) -fPIC
+LDFLAGS        := $(LDFLAGS) -Wl,-headerpad_max_install_names

--- a/recipe/Makefile.inc.Linux
+++ b/recipe/Makefile.inc.Linux
@@ -1,22 +1,5 @@
 # -*- makefile -*-
-EXE             =
-LIB             = .a
-OBJ             = .o
+src_dir := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+include $(src_dir)/Makefile.inc.common
 
-MAKE            = make
-AR              = ar
-ARFLAGS         = -ruv
-CAT             = cat
-CCS             = gcc
-CCP             = gcc
-CCD             = gcc
-CFLAGS          = -I${PREFIX}/include -O3 -DIDXSIZE64 -Drestrict=__restrict -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_RANDOM_FIXED_SEED -DSCOTCH_RENAME -DCOMMON_PTHREAD -DSCOTCH_PTHREAD
-CLIBFLAGS       = -fPIC
-LDFLAGS         = -L${PREFIX}/lib -lz -lm -pthread -lrt
-CP              = cp
-LEX             = flex -Pscotchyy -olex.yy.c
-LN              = ln
-MKDIR           = mkdir
-MV              = mv
-RANLIB          = ranlib
-YACC            = bison -pscotchyy -y -b y
+LDFLAGS        := ${LDFLAGS} -lrt

--- a/recipe/Makefile.inc.Linux
+++ b/recipe/Makefile.inc.Linux
@@ -1,5 +1,0 @@
-# -*- makefile -*-
-src_dir := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-include $(src_dir)/Makefile.inc.common
-
-LDFLAGS        := ${LDFLAGS} -lrt

--- a/recipe/Makefile.inc.common
+++ b/recipe/Makefile.inc.common
@@ -1,0 +1,22 @@
+# -*- makefile -*-
+EXE             =
+LIB             = .a
+OBJ             = .o
+
+MAKE            = make
+AR              = ar
+ARFLAGS         = -ruv
+CAT             = cat
+CCS             = gcc
+CCP             = mpicc
+CCD             = gcc
+CFLAGS          = -I${PREFIX}/include -O3 -DIDXSIZE64 -Drestrict=__restrict -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_RANDOM_FIXED_SEED -DSCOTCH_RENAME -DCOMMON_PTHREAD -DCOMMON_PTHREAD_BARRIER -DSCOTCH_PTHREAD
+CLIBFLAGS       =
+LDFLAGS         = -L${PREFIX}/lib -lz -lm -pthread
+CP              = cp
+LEX             = flex -Pscotchyy --no-yywrap -olex.yy.c
+LN              = ln
+MKDIR           = mkdir
+MV              = mv
+RANLIB          = ranlib
+YACC            = bison -pscotchyy -y -b y

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+cp $RECIPE_DIR/Makefile.inc.common src/Makefile.inc.common
 cp $RECIPE_DIR/Makefile.inc.$(uname) src/Makefile.inc
 
 cd src/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,10 +1,29 @@
 #!/bin/sh
 
-cp $RECIPE_DIR/Makefile.inc.common src/Makefile.inc.common
-cp $RECIPE_DIR/Makefile.inc.$(uname) src/Makefile.inc
+env | sort
+cp $RECIPE_DIR/Makefile.inc src/Makefile.inc
+
+export CFLAGS="${CFLAGS} -I${PREFIX}/include -O3 -DIDXSIZE64 -Drestrict=__restrict -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_RANDOM_FIXED_SEED -DSCOTCH_RENAME -DCOMMON_PTHREAD -DCOMMON_PTHREAD_BARRIER"
+export LDFLAGS="${LDFLAGS} -lz -lm -pthread"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    export CFLAGS="${CFLAGS} -DCOMMON_PTHREAD_BARRIER -DCOMMON_TIMING_OLD"
+    export CLIBFLAGS="${CLIBFLAGS} -fPIC"
+else
+    export LDFLAGS="${LDFLAGS} -lrt"
+fi
+
+if [[ "${PKG_NAME}" == "scotch" ]]; then
+    # serial build
+    export CFLAGS="${CFLAGS} -DSCOTCH_PTHREAD"
+    LIBNAME=esmumps
+else
+    # parallel build
+    LIBNAME=ptesmumps
+fi
 
 cd src/
-make -j ${NUM_CPUS} esmumps | tee make.log 2>&1
+make -j ${NUM_CPUS} ${LIBNAME} | tee make.log 2>&1
 make check
 cd ..
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,7 +23,7 @@ else
 fi
 
 cd src/
-make -j ${NUM_CPUS} ${LIBNAME} | tee make.log 2>&1
+make ${LIBNAME} | tee make.log 2>&1
 make check
 cd ..
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,7 +4,7 @@ cp $RECIPE_DIR/Makefile.inc.common src/Makefile.inc.common
 cp $RECIPE_DIR/Makefile.inc.$(uname) src/Makefile.inc
 
 cd src/
-make esmumps | tee make.log 2>&1
+make -j ${NUM_CPUS} esmumps | tee make.log 2>&1
 make check
 cd ..
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,36 +1,58 @@
-#!/bin/sh
+#!/bin/bash
 
-env | sort
 cp $RECIPE_DIR/Makefile.inc src/Makefile.inc
 
-export CFLAGS="${CFLAGS} -I${PREFIX}/include -O3 -DIDXSIZE64 -Drestrict=__restrict -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_RANDOM_FIXED_SEED -DSCOTCH_RENAME -DCOMMON_PTHREAD -DCOMMON_PTHREAD_BARRIER"
-export LDFLAGS="${LDFLAGS} -lz -lm -pthread"
+export CFLAGS="${CFLAGS} -O3 -I${PREFIX}/include -DIDXSIZE64 -DSCOTCH_RENAME -Drestrict=__restrict -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_RANDOM_FIXED_SEED -DCOMMON_PTHREAD"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib -lz -lm -pthread"
 
-if [[ "$(uname)" == "Darwin" ]]; then
+if [[ $(uname) == "Darwin" ]]; then
     export CFLAGS="${CFLAGS} -DCOMMON_PTHREAD_BARRIER -DCOMMON_TIMING_OLD"
-    export CLIBFLAGS="${CLIBFLAGS} -fPIC"
 else
     export LDFLAGS="${LDFLAGS} -lrt"
 fi
 
-if [[ "${PKG_NAME}" == "scotch" ]]; then
-    # serial build
+if [[ "$PKG_NAME" == "scotch" ]]; then
+    # allow non-mpi scotch to use threads
     export CFLAGS="${CFLAGS} -DSCOTCH_PTHREAD"
-    LIBNAME=esmumps
-else
-    # parallel build
-    LIBNAME=ptesmumps
 fi
 
+# build
 cd src/
-make ${LIBNAME} | tee make.log 2>&1
+make esmumps 2>&1 | tee -a make.log
 make check
 cd ..
 
-# install.
+# install
 mkdir -p $PREFIX/lib/
 cp lib/* $PREFIX/lib/
 mkdir -p $PREFIX/bin/
 cp bin/* $PREFIX/bin/
 mkdir -p $PREFIX/include/
 cp include/* $PREFIX/include/
+
+if [[ "$PKG_NAME" == "ptscotch" ]]; then
+
+    export HYDRA_LAUNCHER=fork
+    export MPIEXEC="bash ${RECIPE_DIR}/mpiexec.sh"
+
+    if [[ "$(uname)" == "Linux" ]]; then
+      # skip mpiexec tests on Linux due to conda-forge bug:
+      # https://github.com/conda-forge/conda-smithy/pull/337
+      export MPIEXEC="echo SKIPPING $MPIEXEC"
+    fi
+
+    # build
+    cd src/
+    make ptesmumps 2>&1 | tee -a make.log
+    make ptcheck EXECP="$MPIEXEC -n 4"
+    cd ..
+
+    # install
+    mkdir -p $PREFIX/lib/
+    cp lib/libpt* $PREFIX/lib/
+    mkdir -p $PREFIX/bin/
+    cp bin/dg* $PREFIX/bin/
+    mkdir -p $PREFIX/include/
+    cp include/ptscotch*.h $PREFIX/include/
+    cp include/parmetis.h  $PREFIX/include/
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 2
+  number: 3
 
 requirements:
  build:


### PR DESCRIPTION
only include deviations from default in platform Makefiles

build number is bumped because -DSCOTCH_PTHREAD is restored, which had been removed.