### PR TITLE
restore mpiexec tests on Darwin

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -40,16 +40,11 @@ export CCP=mpicc
 export CCD=${CCP}
 
 export HYDRA_LAUNCHER=fork
-export MPIEXEC=mpiexec
+export MPIEXEC="${RECIPE_DIR}/mpiexec.sh"
+
 if [[ "$(uname)" == "Linux" ]]; then
   # skip mpiexec tests on Linux due to conda-forge bug:
   # https://github.com/conda-forge/conda-smithy/pull/337
-  export MPIEXEC="echo SKIPPING $MPIEXEC"
-fi
-if [[ "$(uname)" == "Darwin" ]]; then
-  # the following test fails with "write error"
-  # on Travis-CI during 'make ptcheck'
-  # $ mpiexec -n 4 ./test_scotch_dgraph_redist data/bump.grf
   export MPIEXEC="echo SKIPPING $MPIEXEC"
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -42,12 +42,6 @@ export CCD=${CCP}
 export HYDRA_LAUNCHER=fork
 export MPIEXEC="${RECIPE_DIR}/mpiexec.sh"
 
-if [[ "$(uname)" == "Linux" ]]; then
-  # skip mpiexec tests on Linux due to conda-forge bug:
-  # https://github.com/conda-forge/conda-smithy/pull/337
-  export MPIEXEC="echo SKIPPING $MPIEXEC"
-fi
-
 # build
 cd src/
 make ptesmumps 2>&1 | tee make.log

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,11 +31,13 @@ requirements:
  run:
   - zlib 1.2.*
   {% if name == 'ptscotch' %}
-  - scotch
+  - scotch {{version}}
   - mpich 3.2.*
   {% endif %}
 
 test:
+  requires:
+    - toolchain
   commands:
     {% if name == 'scotch' %}
     - test -f "${PREFIX}/lib/libscotch.a"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 3 %}
+{% set build = 4 %}
 {% set version = "6.0.4" %}
 {% set name = "ptscotch" %}
 {% set md5 = "d58b825eb95e1db77efe8c6ff42d329f" %}

--- a/recipe/mpiexec.sh
+++ b/recipe/mpiexec.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+mpiexec $@
+ec=$?
+
+# fix O_NONBLOCK
+python $(dirname "$0")/no-nonblock.py
+exit $ec

--- a/recipe/mpiexec.sh
+++ b/recipe/mpiexec.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 # pipe stdout, stderr through cat to avoid O_NONBLOCK issues
-mpiexec $@ 2>&1 | cat
+echo '' | mpiexec $@ 2>&1 | cat

--- a/recipe/mpiexec.sh
+++ b/recipe/mpiexec.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-mpiexec $@
-ec=$?
-
-# fix O_NONBLOCK
-python $(dirname "$0")/no-nonblock.py
-exit $ec
+set -e
+# pipe stdout, stderr through cat to avoid O_NONBLOCK issues
+mpiexec $@ 2>&1 | cat

--- a/recipe/no-nonblock.py
+++ b/recipe/no-nonblock.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import os, sys, fcntl
+for name in ('stdout', 'stderr', 'stdin'):
+    fd = getattr(sys, name).fileno()
+    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+    if flags & os.O_NONBLOCK:
+        fcntl.fcntl(fd, fcntl.F_SETFL, flags ^ os.O_NONBLOCK)
+        print("fixing %s" % name)

--- a/recipe/no-nonblock.py
+++ b/recipe/no-nonblock.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-import os, sys, fcntl
-for name in ('stdout', 'stderr', 'stdin'):
-    fd = getattr(sys, name).fileno()
-    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
-    if flags & os.O_NONBLOCK:
-        fcntl.fcntl(fd, fcntl.F_SETFL, flags ^ os.O_NONBLOCK)
-        print("fixing %s" % name)

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,10 @@
+if [[ "${PKG_NAME}" == "ptscotch" ]]; then
+
+mpic++ $CXXFLAGS "-I$PREFIX/include" "-L$PREFIX/lib" "${RECIPE_DIR}/test/test_ptscotch.cxx" -o test_ptscotch -DSCOTCH_PTSCOTCH -lptscotch -lptscotcherr
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    # FIXME: mpiexec messes with docker (CircleCI) builds
+    ${RECIPE_DIR}/mpiexec.sh ./test_ptscotch
+fi
+
+fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,10 +1,7 @@
 if [[ "${PKG_NAME}" == "ptscotch" ]]; then
 
 mpic++ $CXXFLAGS "-I$PREFIX/include" "-L$PREFIX/lib" "${RECIPE_DIR}/test/test_ptscotch.cxx" -o test_ptscotch -DSCOTCH_PTSCOTCH -lptscotch -lptscotcherr
-
-if [[ "$(uname)" == "Darwin" ]]; then
-    # FIXME: mpiexec messes with docker (CircleCI) builds
-    ${RECIPE_DIR}/mpiexec.sh ./test_ptscotch
-fi
+# use mpiexec.sh wrapper to avoid O_NONBLOCK issues
+${RECIPE_DIR}/mpiexec.sh ./test_ptscotch
 
 fi

--- a/recipe/test/test_ptscotch.cxx
+++ b/recipe/test/test_ptscotch.cxx
@@ -1,0 +1,29 @@
+// test source: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=612621
+#include <iostream>
+#include <cstdlib>
+
+#include <mpi.h>
+#include <ptscotch.h>
+
+int main() {
+  int provided;
+  SCOTCH_Dgraph dgrafdat;
+
+  MPI_Init_thread(0, 0, MPI_THREAD_MULTIPLE, &provided);
+
+  if (SCOTCH_dgraphInit(&dgrafdat, MPI_COMM_WORLD) != 0) {
+    if (MPI_THREAD_MULTIPLE > provided) {
+      std::cout << "MPI implementation is not thread-safe:" << std::endl;
+      std::cout << "SCOTCH should be compiled without SCOTCH_PTHREAD"
+<< std::endl;
+      exit(1);
+    }
+  }
+  else {
+    SCOTCH_dgraphExit(&dgrafdat);
+  }
+
+  MPI_Finalize();
+
+  return 0;
+}


### PR DESCRIPTION
still can't run on Linux due to O_NONBLOCK issues