### PR TITLE
avoid conflicts with metis.h

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,7 +28,10 @@ cp lib/* $PREFIX/lib/
 mkdir -p $PREFIX/bin/
 cp bin/* $PREFIX/bin/
 mkdir -p $PREFIX/include/
-cp include/* $PREFIX/include/
+# avoid conflicts with the real metis.h
+mkdir -p include/scotch
+mv include/metis.h include/scotch/
+cp -rv include/* $PREFIX/include/
 
 fi # scotch
 
@@ -54,6 +57,8 @@ mkdir -p $PREFIX/bin/
 cp bin/dg* $PREFIX/bin/
 mkdir -p $PREFIX/include/
 cp include/ptscotch*.h $PREFIX/include/
-cp include/parmetis.h  $PREFIX/include/
+# avoid conflicts with the real parmetis.h
+mkdir -p $PREFIX/include/scotch
+cp include/parmetis.h  $PREFIX/include/scotch/
 
 fi # ptscotch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 3 %}
+{% set build = 4 %}
 {% set version = "6.0.4" %}
 {% set name = "scotch" %}
 {% set md5 = "d58b825eb95e1db77efe8c6ff42d329f" %}
@@ -47,7 +47,8 @@ test:
     - test -f "${PREFIX}/lib/libesmumps.a"
     - test -f "${PREFIX}/include/scotch.h"
     - test -f "${PREFIX}/include/scotchf.h"
-    - test -f "${PREFIX}/include/metis.h"
+    - test -f "${PREFIX}/include/scotch/metis.h"
+    - test ! -f "${PREFIX}/include/metis.h"
     - test -f "${PREFIX}/include/esmumps.h"
     - mord -V
     - gmap -V
@@ -63,7 +64,8 @@ test:
     - test -f "${PREFIX}/lib/libptesmumps.a"
     - test -f "${PREFIX}/include/ptscotch.h"
     - test -f "${PREFIX}/include/ptscotchf.h"
-    - test -f "${PREFIX}/include/parmetis.h"
+    - test -f "${PREFIX}/include/scotch/parmetis.h"
+    - test ! -f "${PREFIX}/include/parmetis.h"
     - test -f "${PREFIX}/include/esmumps.h"
     - dggath -V
     - dgmap -V


### PR DESCRIPTION
by putting them in `include/scotch/` so they don’t conflict with the ‘real’ headers from metis/parmetis packages.

closes #24 (for scotch)