### PR TITLE
bump build to get latest openmpi 3.1.3

### DIFF
--- a/.ci_support/linux_c_compilergccfortran_compilergfortranmpimpich.yaml
+++ b/.ci_support/linux_c_compilergccfortran_compilergfortranmpimpich.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 flex:
 - 2.6.0
 fortran_compiler:

--- a/.ci_support/linux_c_compilergccfortran_compilergfortranmpiopenmpi.yaml
+++ b/.ci_support/linux_c_compilergccfortran_compilergfortranmpiopenmpi.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 flex:
 - 2.6.0
 fortran_compiler:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scotch" %}
-{% set build = 1000 %}
+{% set build = 1001 %}
 {% set version = "6.0.6" %}
 {% set sha256 = "686f0cad88d033fe71c8b781735ff742b73a1d82a65b8b1586526d69729ac4cf" %}
 


### PR DESCRIPTION
This may not matter, but I have a hunch that mumps is having compatibility issues with earlier builds with ompi 3.1.2