### PR TITLE
Build without `--as-needed`

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,10 @@
 set -ex
 cp $RECIPE_DIR/Makefile.inc src/Makefile.inc
 
+# remove --as-needed, which removes librt
+# even though libscotch requires clock_gettime from librt
+export LDFLAGS="${LDFLAGS/-Wl,--as-needed/}"
+
 if [[ $(uname) == "Darwin" ]]; then
   export SONAME="-Wl,-install_name,@rpath/"
 else

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scotch" %}
-{% set build = 1001 %}
+{% set build = 1002 %}
 {% set version = "6.0.6" %}
 {% set sha256 = "686f0cad88d033fe71c8b781735ff742b73a1d82a65b8b1586526d69729ac4cf" %}
 


### PR DESCRIPTION
--as-needed strips some dependencies like librt, which are actually required by libscotch

cf https://github.com/conda-forge/ipopt-feedstock/pull/24#issuecomment-442937324