### PR TITLE
various fixes for 7.0.5

### DIFF
--- a/recipe/0002-add-COMPONENT-labels-for-easier-split-installation.patch
+++ b/recipe/0002-add-COMPONENT-labels-for-easier-split-installation.patch
@@ -1,0 +1,26 @@
+From a18e395cafa2fb3ebd551449b3b23b950d191361 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Fri, 20 May 2022 15:11:19 +0200
+Subject: [PATCH 2/4] add COMPONENT labels for easier split installation
+
+---
+iff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4531d15..f829e15 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -83,4 +83,4 @@ option(INSTALL_METIS_HEADERS "Install libScotchMeTiS headers in destination dire
+ add_subdirectory(src)
+ 
+ # Install man pages
+-install(DIRECTORY man/man1 DESTINATION man FILES_MATCHING PATTERN "*.1")
++install(DIRECTORY man/man1 DESTINATION man COMPONENT scotch FILES_MATCHING PATTERN "*.1")
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 3a924e6..253ea15 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -184,4 +184,5 @@ write_basic_package_version_file(SCOTCHConfigVersion.cmake
+ # Install config files
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/SCOTCHConfig.cmake
+   ${CMAKE_CURRENT_BINARY_DIR}/SCOTCHConfigVersion.cmake
++  COMPONENT libscotch
+   DESTINATION ${LIBRARY_INSTALL_DIR}/cmake/scotch)

--- a/recipe/0002-add-COMPONENT-labels-for-easier-split-installation.patch
+++ b/recipe/0002-add-COMPONENT-labels-for-easier-split-installation.patch
@@ -1,26 +1,13 @@
-From a18e395cafa2fb3ebd551449b3b23b950d191361 Mon Sep 17 00:00:00 2001
-From: Min RK <benjaminrk@gmail.com>
-Date: Fri, 20 May 2022 15:11:19 +0200
-Subject: [PATCH 2/4] add COMPONENT labels for easier split installation
-
+install SCOTCHConfig with libscotch
 ---
-iff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4531d15..f829e15 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -83,4 +83,4 @@ option(INSTALL_METIS_HEADERS "Install libScotchMeTiS headers in destination dire
- add_subdirectory(src)
- 
- # Install man pages
--install(DIRECTORY man/man1 DESTINATION man FILES_MATCHING PATTERN "*.1")
-+install(DIRECTORY man/man1 DESTINATION man COMPONENT scotch FILES_MATCHING PATTERN "*.1")
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 3a924e6..253ea15 100644
+index 1c05a82..3df183b 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -184,4 +184,5 @@ write_basic_package_version_file(SCOTCHConfigVersion.cmake
+@@ -215,5 +215,5 @@ write_basic_package_version_file(SCOTCHConfigVersion.cmake
  # Install config files
  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/SCOTCHConfig.cmake
    ${CMAKE_CURRENT_BINARY_DIR}/SCOTCHConfigVersion.cmake
+-  COMPONENT scotch
 +  COMPONENT libscotch
-   DESTINATION ${LIBRARY_INSTALL_DIR}/cmake/scotch)
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/scotch)

--- a/recipe/link-scotcherr.patch
+++ b/recipe/link-scotcherr.patch
@@ -1,0 +1,29 @@
+From 34195b53c829a55584d61b1c8b8ca3eb620d95d7 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Thu, 26 Sep 2024 23:48:00 +0200
+Subject: [PATCH] link error libraries
+
+---
+diff --git a/src/libscotch/CMakeLists.txt b/src/libscotch/CMakeLists.txt
+index f314d3a..71532f6 100644
+--- a/src/libscotch/CMakeLists.txt
++++ b/src/libscotch/CMakeLists.txt
+@@ -517,6 +517,7 @@ add_dependencies(scotch parser_yy_c parser_ll_c)
+ if(NOT WIN32)
+   target_link_libraries(scotch PUBLIC m)
+ endif(NOT WIN32)
++target_link_libraries(scotch PUBLIC scotcherr)
+ target_include_directories(scotch PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+@@ -772,6 +773,7 @@ if(BUILD_PTSCOTCH)
+     SOVERSION ${SCOTCH_VERSION}.${SCOTCH_RELEASE}
+     COMPILE_FLAGS -DSCOTCH_PTSCOTCH)
+ 
++  target_link_libraries(ptscotch PUBLIC ptscotcherr)
+   target_link_libraries(ptscotch PUBLIC scotch MPI::MPI_C)
+ 
+   target_include_directories(ptscotch PUBLIC
+-- 
+2.45.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
   patches:
     - 0001-put-metis-headers-in-include-scotch.patch
     - 0002-fix-ptesmumps.h.patch
+    - 0002-add-COMPONENT-labels-for-easier-split-installation.patch
     - 0003-win-fix-ssize_t.patch
     - 0004-win-fix-context.c.patch  # [win]
     - 0005-win-fix-flex.patch
@@ -24,7 +25,7 @@ source:
     - 0010-fix-idxsize.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libscotch
@@ -83,6 +84,8 @@ outputs:
         - if exist %PREFIX%\\Library\\include\\scotch\\metis.h (exit 0) else (exit 1)  # [win]
         - test ! -f "${PREFIX}/bin/gord"                                               # [unix]
         - if exist %PREFIX%\\Library\\bin\\gord.exe (exit 1) else (exit 0)             # [win]
+        - test -f "$PREFIXlib/cmake/scotch/SCOTCHConfig.cmake"                        # [unix]
+        - if not exist %LIBRARY_PREFIX\lib\cmake\scotch\SCOTCHConfig.cmake exit 1      # [win]
 
   - name: libptscotch
     build:
@@ -147,8 +150,6 @@ outputs:
         - if exist %PREFIX%\\Library\\bin\\gord.exe (exit 0) else (exit 1)             # [win]
         - test ! -f "${PREFIX}/bin/dgord"                                              # [unix]
         - if exist %PREFIX%\\Library\\bin\\dgord.exe (exit 1) else (exit 0)            # [win]
-        - test -f "$PREFIX/lib/cmake/scotch/SCOTCHConfig.cmake"                        # [unix]
-        - if not exist %LIBRARY_PREFIX\lib\cmake\scotch\SCOTCHConfig.cmake exit 1      # [win]
 
   - name: ptscotch
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,7 +107,6 @@ outputs:
     test:
       script: run_test.sh  # [unix]
       requires:
-        - cmake
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ outputs:
       script: "%RECIPE_DIR%\\bld-scotch.bat"  # [win]
       run_exports:
         - {{ pin_subpackage('libscotch', max_pin='x.x.x') }}
-      ignore_run_exports:
+      ignore_run_exports_from:
         - {{ mpi }}
     requirements:
       build:
@@ -133,15 +133,12 @@ outputs:
     build:
       script: cmake --install ./build --component=scotch
       run_exports:
-        - {{ pin_subpackage('scotch', max_pin='x.x.x') }}
-      ignore_run_exports:
-        - {{ mpi }}
+        - {{ pin_subpackage('libscotch', max_pin='x.x.x') }}
+      force_use_keys:
+        - mpi
     requirements:
       build:
         - cmake
-      host:
-        # This is needed to get the correct package hash
-        - {{ mpi }}
       run:
         - {{ pin_subpackage('libscotch', exact=True) }}
     test:
@@ -157,13 +154,12 @@ outputs:
     build:
       script: cmake --install ./build --component=ptscotch
       run_exports:
-        - {{ pin_subpackage('ptscotch', max_pin='x.x.x') }}
+        - {{ pin_subpackage('libptscotch', max_pin='x.x.x') }}
+      force_use_keys:
+        - mpi
     requirements:
       build:
         - cmake
-      host:
-        # This is needed to get the correct package hash
-        - {{ mpi }}
       run:
         - {{ pin_subpackage('libptscotch', exact=True) }}
         - {{ pin_subpackage('scotch', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,7 +84,7 @@ outputs:
         - if exist %PREFIX%\\Library\\include\\scotch\\metis.h (exit 0) else (exit 1)  # [win]
         - test ! -f "${PREFIX}/bin/gord"                                               # [unix]
         - if exist %PREFIX%\\Library\\bin\\gord.exe (exit 1) else (exit 0)             # [win]
-        - test -f "$PREFIXlib/cmake/scotch/SCOTCHConfig.cmake"                        # [unix]
+        - test -f "$PREFIX/lib/cmake/scotch/SCOTCHConfig.cmake"                        # [unix]
         - if not exist %LIBRARY_PREFIX\lib\cmake\scotch\SCOTCHConfig.cmake exit 1      # [win]
 
   - name: libptscotch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
   url: https://gitlab.inria.fr/scotch/scotch/-/archive/v{{ version }}/scotch-v{{ version }}.tar.gz
   sha256: 385507a9712bb9057497b9ac3f24ad2132bd3f3f8c7a62e78324fc58f2a0079b
   patches:
+    - link-scotcherr.patch
     - 0001-put-metis-headers-in-include-scotch.patch
     - 0002-fix-ptesmumps.h.patch
     - 0002-add-COMPONENT-labels-for-easier-split-installation.patch
@@ -59,8 +60,10 @@ outputs:
         - pthreads-win32  # [win]
 
     test:
+      script: run_test.sh  # [unix]
       requires:
         - {{ compiler('c') }}
+        - python
       commands:
         {% for lib in [
           'scotch',
@@ -102,10 +105,12 @@ outputs:
       run:
         - {{ pin_subpackage("libscotch", exact=True) }}
     test:
+      script: run_test.sh  # [unix]
       requires:
         - cmake
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - python
       commands:
         {% for lib in [
           'ptscotch',
@@ -145,6 +150,7 @@ outputs:
       run:
         - {{ pin_subpackage('libscotch', exact=True) }}
     test:
+      script: run_test.sh  # [unix]
       commands:
         - test -f "${PREFIX}/bin/gord"                                                 # [unix]
         - if exist %PREFIX%\\Library\\bin\\gord.exe (exit 0) else (exit 1)             # [win]
@@ -165,6 +171,7 @@ outputs:
         - {{ pin_subpackage('libptscotch', exact=True) }}
         - {{ pin_subpackage('scotch', exact=True) }}
     test:
+      script: run_test.sh  # [unix]
       commands:
         - test -f "${PREFIX}/bin/gord"                                       # [unix]
         - if exist %PREFIX%\\Library\\bin\\gord.exe (exit 0) else (exit 1)   # [win]

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 set -xeuo pipefail
 
+# make sure DLLs can be loaded
+if [[ "${PKG_NAME}" == "libscotch" ]]
+then
+  python3 -c "import ctypes; ctypes.CDLL('${PREFIX}/lib/libscotch${SHLIB_EXT}')"
+fi
+
+if [[ "${PKG_NAME}" == "libptscotch" ]]
+then
+  python3 -c "import ctypes; ctypes.CDLL('${PREFIX}/lib/libptscotch${SHLIB_EXT}')"
+fi
+
+
 if [[ "${PKG_NAME}" == "scotch" ]]
 then
 
@@ -8,7 +20,6 @@ then
   gmap -V
   gord -V
   gotst -V
-  gpart -V
   gscat -V
 
 fi # scotch
@@ -29,7 +40,6 @@ then
   dggath -V
   dgmap -V
   dgord -V
-  dgpart -V
   dgscat -V
   dgtst -V
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -10,6 +10,9 @@ fi
 if [[ "${PKG_NAME}" == "libptscotch" ]]
 then
   python3 -c "import ctypes; ctypes.CDLL('${PREFIX}/lib/libptscotch${SHLIB_EXT}')"
+
+  mpic++ $CXXFLAGS $LDFLAGS "-I$PREFIX/include" "-L$PREFIX/lib" "${RECIPE_DIR}/test/test_ptscotch.cxx" -o test_ptscotch -DSCOTCH_PTSCOTCH -lptscotch -lptscotcherr
+  mpiexec -n 1 ./test_ptscotch
 fi
 
 
@@ -28,22 +31,10 @@ fi # scotch
 if [[ "${PKG_NAME}" == "ptscotch" ]]
 then
 
-  MPIEXEC="${RECIPE_DIR}/mpiexec.sh"
-  mpiexec() { $MPIEXEC $@; }
-
-  # These `dg*` tools do not call MPI_Finalize() in some cases and then
-  # Open MPI's mpiexec complain about that. Let them run in singleton
-  # mode, outside of mpiexec's control, with a quick workaround for
-  # docker images without `ssh`/`rsh` commands.
-  export OMPI_MCA_plm_rsh_agent=false
-
   dggath -V
   dgmap -V
   dgord -V
   dgscat -V
   dgtst -V
-
-  mpic++ $CXXFLAGS $LDFLAGS "-I$PREFIX/include" "-L$PREFIX/lib" "${RECIPE_DIR}/test/test_ptscotch.cxx" -o test_ptscotch -DSCOTCH_PTSCOTCH -lptscotch -lptscotcherr
-  mpiexec -n 1 ./test_ptscotch
 
 fi # ptscotch

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -11,7 +11,7 @@ if [[ "${PKG_NAME}" == "libptscotch" ]]
 then
   python3 -c "import ctypes; ctypes.CDLL('${PREFIX}/lib/libptscotch${SHLIB_EXT}')"
 
-  mpic++ $CXXFLAGS $LDFLAGS "-I$PREFIX/include" "-L$PREFIX/lib" "${RECIPE_DIR}/test/test_ptscotch.cxx" -o test_ptscotch -DSCOTCH_PTSCOTCH -lptscotch -lptscotcherr
+  mpic++ $CXXFLAGS $LDFLAGS "-I$PREFIX/include" "-L$PREFIX/lib" "${RECIPE_DIR}/parent/test/test_ptscotch.cxx" -o test_ptscotch -DSCOTCH_PTSCOTCH -lptscotch -lptscotcherr
   mpiexec -n 1 ./test_ptscotch
 fi
 


### PR DESCRIPTION
accumulates a few fixes for 7.0.5:

- the important one: restores patch linking libscotch -> libscotcherr (and tests that libscotch can be `dlopen`ed to catch future regressions), cause of https://github.com/conda-forge/ipopt-feedstock/issues/114
- add run_exports on `lib` variants, so rather than scotch -> scotch, scotch -> libscotch, etc.

  this is because the executables in 'scotch' aren't necessarily a runtime dependency. If that's what packages want, they should explicitly depend on it in `run`.

- Also fixes the lost patch (#86) to include cmake files in libscotch, which I missed in review
- and minor improvements to interactions with mpi variants:
  - use `force_use_keys` to include it in the hash, rather than putting it in `host`, which avoids an unnecessary installations of mpi during the build
  - use `ignore_run_exports_from` instead of `ignore_run_exports`, which is more precisely correct (ignore run_exports _from_ the mpich package, vs ignore run_exports _on_ the mpich package), though the results happen to be the same at the moment.