### PR TITLE
msmpi lacks run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
     - 0010-fix-idxsize.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: libscotch
@@ -104,6 +104,8 @@ outputs:
         - {{ mpi }}
       run:
         - {{ pin_subpackage("libscotch", exact=True) }}
+        # msmpi has no run_exports
+        - {{ pin_compatible("msmpi", max_pin="x.x") }}  # [mpi == 'msmpi']
     test:
       script: run_test.sh  # [unix]
       requires:


### PR DESCRIPTION
so msmpi builds have no dependency on msmpi