### PR TITLE
use `liblzma` instead of `xz`

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,27 +11,27 @@ jobs:
       linux_64_mpimpich:
         CONFIG: linux_64_mpimpich
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_mpiopenmpi:
         CONFIG: linux_64_mpiopenmpi
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_mpimpich:
         CONFIG: linux_aarch64_mpimpich
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
       linux_aarch64_mpiopenmpi:
         CONFIG: linux_aarch64_mpiopenmpi
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
       linux_ppc64le_mpimpich:
         CONFIG: linux_ppc64le_mpimpich
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
       linux_ppc64le_mpiopenmpi:
         CONFIG: linux_ppc64le_mpiopenmpi
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -27,6 +27,7 @@ jobs:
       displayName: Run Windows build
       env:
         MINIFORGE_HOME: $(MINIFORGE_HOME)
+        CONDA_BLD_PATH: $(CONDA_BLD_PATH)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -19,11 +19,17 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+liblzma_devel:
+- '5'
+libptscotch:
+- 7.0.5
+libscotch:
+- 7.0.5
 mpi:
 - mpich
 mpich:
@@ -34,8 +40,6 @@ scotch:
 - 7.0.5
 target_platform:
 - linux-64
-xz:
-- '5'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -19,11 +19,17 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+liblzma_devel:
+- '5'
+libptscotch:
+- 7.0.5
+libscotch:
+- 7.0.5
 mpi:
 - openmpi
 mpich:
@@ -34,8 +40,6 @@ scotch:
 - 7.0.5
 target_platform:
 - linux-64
-xz:
-- '5'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_mpimpich.yaml
+++ b/.ci_support/linux_aarch64_mpimpich.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 bzip2:
 - '1'
 c_compiler:
@@ -10,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -23,11 +19,17 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+liblzma_devel:
+- '5'
+libptscotch:
+- 7.0.5
+libscotch:
+- 7.0.5
 mpi:
 - mpich
 mpich:
@@ -38,8 +40,6 @@ scotch:
 - 7.0.5
 target_platform:
 - linux-aarch64
-xz:
-- '5'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_mpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpi.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 bzip2:
 - '1'
 c_compiler:
@@ -10,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -23,11 +19,17 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+liblzma_devel:
+- '5'
+libptscotch:
+- 7.0.5
+libscotch:
+- 7.0.5
 mpi:
 - openmpi
 mpich:
@@ -38,8 +40,6 @@ scotch:
 - 7.0.5
 target_platform:
 - linux-aarch64
-xz:
-- '5'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_mpimpich.yaml
@@ -19,11 +19,17 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+liblzma_devel:
+- '5'
+libptscotch:
+- 7.0.5
+libscotch:
+- 7.0.5
 mpi:
 - mpich
 mpich:
@@ -34,8 +40,6 @@ scotch:
 - 7.0.5
 target_platform:
 - linux-ppc64le
-xz:
-- '5'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_mpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpi.yaml
@@ -19,11 +19,17 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+liblzma_devel:
+- '5'
+libptscotch:
+- 7.0.5
+libscotch:
+- 7.0.5
 mpi:
 - openmpi
 mpich:
@@ -34,8 +40,6 @@ scotch:
 - 7.0.5
 target_platform:
 - linux-ppc64le
-xz:
-- '5'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_mpimpich.yaml
+++ b/.ci_support/osx_64_mpimpich.yaml
@@ -24,6 +24,12 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+liblzma_devel:
+- '5'
+libptscotch:
+- 7.0.5
+libscotch:
+- 7.0.5
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:
@@ -36,8 +42,6 @@ scotch:
 - 7.0.5
 target_platform:
 - osx-64
-xz:
-- '5'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_mpiopenmpi.yaml
+++ b/.ci_support/osx_64_mpiopenmpi.yaml
@@ -24,6 +24,12 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+liblzma_devel:
+- '5'
+libptscotch:
+- 7.0.5
+libscotch:
+- 7.0.5
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:
@@ -36,8 +42,6 @@ scotch:
 - 7.0.5
 target_platform:
 - osx-64
-xz:
-- '5'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_arm64_mpimpich.yaml
+++ b/.ci_support/osx_arm64_mpimpich.yaml
@@ -24,6 +24,12 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+liblzma_devel:
+- '5'
+libptscotch:
+- 7.0.5
+libscotch:
+- 7.0.5
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:
@@ -36,8 +42,6 @@ scotch:
 - 7.0.5
 target_platform:
 - osx-arm64
-xz:
-- '5'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_arm64_mpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpi.yaml
@@ -24,6 +24,12 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+liblzma_devel:
+- '5'
+libptscotch:
+- 7.0.5
+libscotch:
+- 7.0.5
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:
@@ -36,8 +42,6 @@ scotch:
 - 7.0.5
 target_platform:
 - osx-arm64
-xz:
-- '5'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/win_64_mpiimpi-devel.yaml
+++ b/.ci_support/win_64_mpiimpi-devel.yaml
@@ -14,6 +14,12 @@ fortran_compiler:
 - flang
 fortran_compiler_version:
 - '5'
+liblzma_devel:
+- '5'
+libptscotch:
+- 7.0.5
+libscotch:
+- 7.0.5
 mpi:
 - impi-devel
 mpich:
@@ -24,7 +30,5 @@ scotch:
 - 7.0.5
 target_platform:
 - win-64
-xz:
-- '5'
 zlib:
 - '1'

--- a/.ci_support/win_64_mpimsmpi.yaml
+++ b/.ci_support/win_64_mpimsmpi.yaml
@@ -14,6 +14,12 @@ fortran_compiler:
 - flang
 fortran_compiler_version:
 - '5'
+liblzma_devel:
+- '5'
+libptscotch:
+- 7.0.5
+libscotch:
+- 7.0.5
 mpi:
 - msmpi
 mpich:
@@ -24,7 +30,5 @@ scotch:
 - 7.0.5
 target_platform:
 - win-64
-xz:
-- '5'
 zlib:
 - '1'

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -36,6 +36,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
 del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+call :end_group
 
 call :start_group "Configuring conda"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
     - 0010-fix-idxsize.patch
 
 build:
-  number: 3
+  number: 4
 
 outputs:
   - name: libscotch
@@ -52,7 +52,7 @@ outputs:
       host:
         - zlib
         - bzip2
-        - xz
+        - liblzma-devel
         - {{ mpi }}
         - pthreads-win32  # [win]
       run:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

The `xz` feedstock has been recently splitted into `liblzma` and the `xz-tools`. The `liblzma` is `0BSD` licensed and `xz-tools` as `LGPL` and `GPL` dependening on the set of executables.
Having `GPL` licensed dependencies (due to `xz` runtime exports) is mitigated by using `liblzma` during building this feedstock.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
